### PR TITLE
Fixed Bug #3911

### DIFF
--- a/src/app/components/elements/Voting.scss
+++ b/src/app/components/elements/Voting.scss
@@ -153,6 +153,11 @@
     fill: #fff;
   }
 
+  > .dropdown-comp > .dropdown__content {
+    top: -270px;
+    margin-left: -36px;
+  }
+  
   &.Voting__button--downvoted {
     a path {
       fill: #fff;


### PR DESCRIPTION
This issue also applied when trying to downvote a post at the end of a user's feed and in all other scenarios where the downvote button appears towards the bottom of the screen.

Upvote overlay has a "top: -30px" set so this implementation was replicated with a "top" of -270px for the downvote overlay.

270px was chosen as it allows for the contents of the overlay to be visible when at downvoting the first and last post in a feed.

A margin-left of -36px was added so that the close 'X' button is visible on mobile devices. (left did not work due to 'left: 0%' being set in the Dropdown.scss file.