### PR TITLE
#3915 Bug Fix

### DIFF
--- a/src/app/components/cards/PostFull.scss
+++ b/src/app/components/cards/PostFull.scss
@@ -82,6 +82,7 @@
   }
   > h1 {
     overflow: hidden;
+    overflow-wrap: break-word;
     font-family: $body-font-family;
     font-size: 240%;
     font-weight: 800;


### PR DESCRIPTION
Addition of overflow-wrap property to h1 element so that words longer than the display area are forced to wrap instead of being completely hidden.