### PR TITLE
#proposal 86 hide resteems (#3930)

### DIFF
--- a/src/app/components/cards/PostsList.scss
+++ b/src/app/components/cards/PostsList.scss
@@ -83,7 +83,6 @@
             width: auto;
             padding: 16px;
             margin-top: -31px;
-            color: white;
             font-weight: bold;
             transition: 0.2s ease;
             border-radius: 0 3px 3px 0;
@@ -92,7 +91,8 @@
             opacity: 30%;
             @include font-size(18px);
             @include themify($themes) {
-                background-color: themed('textColorPrimary');
+                background-color: themed('buttonBackground');
+                color: themed('buttonText');
             }
         }
         
@@ -104,7 +104,8 @@
         
         .prev:hover, .next:hover {
             @include themify($themes) {
-                background-color: themed('colorAccent');
+                background-color: themed('buttonBackgroundHover');
+                color: themed('buttonTextHover');
                 opacity: 80%;
             }
         }
@@ -225,4 +226,14 @@
             padding: 0.5rem 0 0.5rem 0.5rem;
         }
     }
+}
+
+input#hideResteems,
+.hideResteemsLabel {
+    padding-bottom: 0.5rem;
+    vertical-align: middle;
+}
+
+.hideResteems {
+    display: none;
 }

--- a/src/app/components/elements/CommunityBanner.jsx
+++ b/src/app/components/elements/CommunityBanner.jsx
@@ -14,8 +14,19 @@ import * as userActions from 'app/redux/UserReducer';
 import * as globalActions from 'app/redux/GlobalReducer';
 
 class CommunityBanner extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            screenWidth: 0,
+        };
+    }
+
     componentDidMount() {
         const { category, profile, fetchProfile } = this.props;
+        this.state = {
+            screenWidth: window.innerWidth,
+            snapWidth: 760,
+        };
         if (!profile) fetchProfile(category);
     }
 
@@ -34,6 +45,8 @@ class CommunityBanner extends Component {
             showRecentSubscribers,
             showModerationLog,
         } = this.props;
+
+        const { screenWidth, snapWidth } = this.state;
 
         const viewer_role = community.getIn(['context', 'role'], 'guest');
         const canPost = Role.canPost(category, viewer_role);
@@ -91,6 +104,18 @@ class CommunityBanner extends Component {
             </SettingsEditButton>
         );
 
+        const formatNumber = num => {
+            if (screenWidth > snapWidth) {
+                return numberWithCommas(num);
+            } else if (num >= 1000000) {
+                return (num / 1000000).toFixed(1) + 'm';
+            } else if (num >= 10000) {
+                return (num / 1000).toFixed(1) + 'k';
+            } else {
+                return numberWithCommas(num);
+            }
+        };
+
         return (
             <div>
                 <div className="UserProfile__banner row expanded">
@@ -108,35 +133,35 @@ class CommunityBanner extends Component {
                                 <Userpic account={category} />
                             )}
                             <div className="TextContainer">
+                                <div className="AdditionalActions">
+                                    <div className="ModeratorRoles">
+                                        {roles && (
+                                            <div>
+                                                {tt('g.edit')}
+                                                {': '}
+                                                {roles}
+                                                {settings && (
+                                                    <span>
+                                                        {' / '}
+                                                        {settings}
+                                                    </span>
+                                                )}
+                                            </div>
+                                        )}
+                                    </div>
+                                    <div className="ActivityLog">
+                                        <a onClick={handleModerationLogCLick}>
+                                            {tt('g.activity_log')}
+                                        </a>
+                                        {community.get('is_nsfw') && (
+                                            <span className="affiliation">
+                                                nsfw
+                                            </span>
+                                        )}
+                                    </div>
+                                </div>
                                 <h1>{community.get('title')}</h1>
                                 <p>{community.get('about')}</p>
-                            </div>
-                            <div className="AdditionalActions">
-                                <div className="ModeratorRoles">
-                                    {roles && (
-                                        <div>
-                                            {tt('g.edit')}
-                                            {': '}
-                                            {roles}
-                                            {settings && (
-                                                <span>
-                                                    {' / '}
-                                                    {settings}
-                                                </span>
-                                            )}
-                                        </div>
-                                    )}
-                                </div>
-                                <div className="ActivityLog">
-                                    <a onClick={handleModerationLogCLick}>
-                                        {tt('g.activity_log')}
-                                    </a>
-                                    {community.get('is_nsfw') && (
-                                        <span className="affiliation">
-                                            nsfw
-                                        </span>
-                                    )}
-                                </div>
                             </div>
                         </div>
                         <div className="CommunityActions">
@@ -165,9 +190,7 @@ class CommunityBanner extends Component {
                                 aria-label="View recent subscribers"
                             >
                                 <p>
-                                    {numberWithCommas(
-                                        community.get('subscribers')
-                                    )}
+                                    {formatNumber(community.get('subscribers'))}
                                     <span className="CommunityLabel">
                                         {community.get('subscribers') == 1
                                             ? tt('g.subscriber')
@@ -176,15 +199,13 @@ class CommunityBanner extends Component {
                                 </p>
                             </div>
                             <p>
-                                ${numberWithCommas(
-                                    community.get('sum_pending')
-                                )}
+                                ${formatNumber(community.get('sum_pending'))}
                                 <span className="CommunityLabel">
                                     {tt('g.pending_rewards')}
                                 </span>
                             </p>
                             <p>
-                                {numberWithCommas(community.get('num_authors'))}
+                                {formatNumber(community.get('num_authors'))}
                                 <span className="CommunityLabel">
                                     {tt('g.active_posters')}
                                 </span>

--- a/src/app/components/elements/CommunityBanner.scss
+++ b/src/app/components/elements/CommunityBanner.scss
@@ -1,6 +1,4 @@
 .CommunityBanner {
-    //display: flex;
-    //align-items: start;
     height: 200px;
     padding: 0;
     position: relative;
@@ -16,9 +14,6 @@
 
     .CommunityTitle {
         background-color: rgba(51,51,51,0.6);
-        //border-top-right-radius: 5px;
-        //border-bottom-right-radius: 5px;
-        //border-right: 1px solid rgba(238, 238, 238, 0.5);
         border-bottom: 1px solid rgba(238, 238, 238, 0.5);
         display: flex;
         flex-basis: 100%;
@@ -29,9 +24,9 @@
         .Userpic {
             border: 2px solid rgb(238, 238, 238);
             margin: 0.5rem;
-            width: 50px !important;
-            min-width: 50px;
-            height: 50px !important;
+            width: 40px !important;
+            min-width: 40px;
+            height: 40px !important;
             @include MQ(M) {
                 margin: 1rem;
                 width: 60px !important;
@@ -41,8 +36,6 @@
         }
 
         .TextContainer {
-            display: flex;
-            flex-direction: column;
             margin: 0.5rem 0;
             width: 100%;
             
@@ -54,17 +47,26 @@
             p {
                 margin: 0;
                 padding: 0 1rem 0 0;
+                font-size: 0.9em;
+                @include MQ(L) {
+                    font-size: 1em;
+                }
             }
         }
     }
 
     .AdditionalActions {
+        float: right;
         color: white;
         border-left: 1px solid rgba(238, 238, 238, 0.5);
-        margin: 0.5rem 0;
+        margin: 0.5rem 0 0 0.5rem;
         padding: 0.5rem 1rem;
         text-align: right;
         white-space: nowrap;
+        font-size: 0.9em;
+        @include MQ(L) {
+            font-size: 1em;
+        }
         
         @include MQ(L) {
             display: none;
@@ -139,10 +141,15 @@
             border-right: 1px solid rgba(238, 238, 238, 0.5);
             line-height: normal;
             text-align: center;
+            font-size: 0.9em;
+            @include MQ(L) {
+                font-size: 1em;
+            }
 
             .CommunityLabel {
                 padding-left: 5px;
                 font-size: 0.8em;
+                white-space: nowrap;
             }
             @include MQ(L) {
                 .CommunityLabel::before {

--- a/src/app/components/pages/PostsIndex.scss
+++ b/src/app/components/pages/PostsIndex.scss
@@ -264,13 +264,9 @@
   }
 
   &__hr {
-    margin-bottom: 20px;
-    margin-top: 0px;
+    display: none;
     @include themify($themes) {
       border-bottom: themed('border');
-    }
-    @include MQ(M) {
-      display: none;
     }
   }
 

--- a/src/app/locales/es.json
+++ b/src/app/locales/es.json
@@ -426,7 +426,7 @@
             "one": "1 publicación",
             "other": "%(count)s posts"
         },
-        "hide_resteems": "Hide Resteems",
+        "hide_resteems": "Ocultar resteems",
         "show_all": "Show All"
     },
     "post_jsx": {

--- a/src/app/locales/fr.json
+++ b/src/app/locales/fr.json
@@ -443,7 +443,7 @@
             "one": "1 article",
             "other": "%(count)s articles"
         },
-        "hide_resteems": "Hide Resteems",
+        "hide_resteems": "Masquer les resteems",
         "show_all": "Show All"
     },
     "post_jsx": {

--- a/src/app/locales/it.json
+++ b/src/app/locales/it.json
@@ -432,7 +432,7 @@
             "one": "1 post",
             "other": "%(count)s post"
         },
-        "hide_resteems": "Hide Resteems",
+        "hide_resteems": "Nascondi resteem",
         "show_all": "Show All"
     },
     "post_jsx": {

--- a/src/app/locales/ja.json
+++ b/src/app/locales/ja.json
@@ -431,7 +431,7 @@
             "one": "投稿1件",
             "other": "投稿%(count)s 件"
         },
-        "hide_resteems": "Hide Resteems",
+        "hide_resteems": "リスティームを非表示にする",
         "show_all": "Show All"
     },
     "post_jsx": {

--- a/src/app/locales/ko.json
+++ b/src/app/locales/ko.json
@@ -429,7 +429,7 @@
             "one": "하나의 게시글",
             "other": "%(count)s 게시글"
         },
-        "hide_resteems": "Hide Resteems",
+        "hide_resteems": "리스팀 숨기기",
         "show_all": "Show All"
     },
     "post_jsx": {

--- a/src/app/locales/pl.json
+++ b/src/app/locales/pl.json
@@ -414,7 +414,7 @@
             "one": "1 wpis",
             "other": "%(count)s wpisów"
         },
-        "hide_resteems": "Hide Resteems",
+        "hide_resteems": "Ukryj resteemy",
         "show_all": "Show All"
     },
     "post_jsx": {

--- a/src/app/locales/ru.json
+++ b/src/app/locales/ru.json
@@ -441,7 +441,7 @@
             "many": "%(count)s постов",
             "other": "%(count)s постов"
         },
-        "hide_resteems": "Hide Resteems",
+        "hide_resteems": "Скрыть ристимы",
         "show_all": "Show All"
     },
     "post_jsx": {


### PR DESCRIPTION
* Bug Fix

Fixed bug #3929 (View / Collapse Doesn't Work with 2 Pinned Posts)

* Implemented Resteems

In combination with bug fix commit - this is the remaining code to implement the hiding of Resteems within a Feed.

* Community Banner Display

Improved the display of the community banner on mobile devices for the following scenarios:
* A community with a large number of subscribers and/or large pending rewards
* A community with a long description

* Hide Resteems Translations

Introduced translations for the "Hide Resteems" label as well as removing comments used whilst debugging.

* Other Friends Feed

Adjusted how the feed being viewed is determined.

* Minor Display Updates

1. Adjusted the colours of the "Next" and "Back" button so that they adjust with the theme (light / dark mode).
2. Tweaked the display of subscribers, pending rewards and active authors on mobile devices so that figures > 10,000 use 10k, 1m, etc. and 1 decimal place.

* Alignment Improvements

Adjusted the positioning and spacing around the "Hide Resteems" button to make it look nicer on mobile and desktop.